### PR TITLE
Better compatibility, version 3

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3'
 
 networks:
     botanic_lan:


### PR DESCRIPTION
Running v3 will run 3.7 on Mac & linux if installed, but no longer throws error on Mac